### PR TITLE
Use pkg-config from distroRoot for probe

### DIFF
--- a/build/libraries.py
+++ b/build/libraries.py
@@ -175,12 +175,20 @@ class FreeType(Library):
 		script = super(FreeType, cls).getConfigScript(
 			platform, linkStatic, distroRoot
 			)
+		# FreeType 2.9.1 no longer installs the freetype-config script
+		# by default and expects pkg-config to be used instead.
 		if isfile(script):
 			return script
-		else:
-			# FreeType 2.9.1 no longer installs the freetype-config script
-			# by default and expects pkg-config to be used instead.
+		elif distroRoot is None:
 			return 'pkg-config freetype2'
+		elif distroRoot.startswith('derived/'):
+			toolsDir = '%s/../tools/bin' % distroRoot
+			for name in listdir(toolsDir):
+				if name.endswith('-pkg-config'):
+					return toolsDir + '/' + name + ' freetype2'
+			raise RuntimeError('No cross-pkg-config found in 3rdparty build')
+		else:
+			return '%s/bin/pkg-config freetype2' % distroRoot
 
 	@classmethod
 	def getVersion(cls, platform, linkStatic, distroRoot):


### PR DESCRIPTION
Previously the one from $PATH was used instead, but this is not
correct when building from 3rdparty.