### PR TITLE
(Hopefully) fix MENU key on Windows.

### DIFF
--- a/src/events/Keys.cc
+++ b/src/events/Keys.cc
@@ -520,6 +520,7 @@ KeyCode getCode(SDL_Keycode key, Uint16 mod, SDL_Scancode scancode, bool release
 	case SDLK_PRINTSCREEN:    result = K_PRINT;             break;
 	case SDLK_SYSREQ:         result = K_SYSREQ;            break;
 //	case SDLK_BREAK:          result = K_BREAK;             break;
+	case SDLK_APPLICATION:    result = K_MENU;              break;
 	case SDLK_MENU:           result = K_MENU;              break;
 	case SDLK_POWER:          result = K_POWER;             break; // Power Macintosh power key
 //	case SDLK_EURO:           result = K_EURO;              break; // Some european keyboards


### PR DESCRIPTION
Based on a commit in Quake 3: http://icculus.org/pipermail/quake3-commits/2014-September/002643.html

As the committer says:

SDL 1.2 converted Windows' VK_APPS and X11 XK_Hyper_R to SDLK_MENU.
SDL2 has it as a separate SDLK_APPLICATION key, so convert it to K_MENU too.